### PR TITLE
Upgrade to proto3

### DIFF
--- a/advertisers.proto
+++ b/advertisers.proto
@@ -1,35 +1,35 @@
-syntax = "proto2";
+syntax = "proto3";
 
 package cakeproto;
 
 import "common.proto";
 
 message Advertiser {
-  optional int64 id = 1;
-  optional string name = 2;
+  int64 id = 1;
+  string name = 2;
 
-  optional IdName account_manager = 3;
-  optional IdName account_status = 4;
+  IdName account_manager = 3;
+  IdName account_status = 4;
 
-  optional string street1 = 5;
-  optional string street2 = 6;
-  optional string city = 7;
-  optional string state = 8;
-  optional string zip_code = 9;
-  optional string country = 10;
-  optional string website = 11;
+  string street1 = 5;
+  string street2 = 6;
+  string city = 7;
+  string state = 8;
+  string zip_code = 9;
+  string country = 10;
+  string website = 11;
 
   repeated Contact contacts = 12;
   repeated IdName tags = 13;
   repeated SuppressionList suppression_lists = 14;
   repeated Blacklist blacklists = 15;
 
-  optional IdName billing_cycle = 16;
-  optional string quickbooks_id = 17;
-  optional bool online_signup = 18;
+  IdName billing_cycle = 16;
+  string quickbooks_id = 17;
+  bool online_signup = 18;
   // signup_ip_address omitted - for privacy reasons
   // api_key omitted - for security reasons
-  optional TimeWithZone date_created = 19;
+  TimeWithZone date_created = 19;
   //date_last_accepted_terms omitted - cannot be reproduced in UI
-  optional string notes = 20;
+  string notes = 20;
 }

--- a/affiliates.proto
+++ b/affiliates.proto
@@ -1,4 +1,4 @@
-syntax = "proto2";
+syntax = "proto3";
 
 package cakeproto;
 
@@ -6,27 +6,27 @@ import "common.proto";
 
 message Affiliate {
   message PaymentType {
-    optional int64 id = 1;
-    optional string name = 2;
-    optional string info = 3;
+    int64 id = 1;
+    string name = 2;
+    string info = 3;
   }
 
-  optional int64 id = 1;
-  optional string name = 2;
+  int64 id = 1;
+  string name = 2;
 
-  optional IdName tier = 3;
-  optional IdName account_manager = 4;
-  optional IdName account_status = 5;
+  IdName tier = 3;
+  IdName account_manager = 4;
+  IdName account_status = 5;
 
-  optional string street1 = 6;
-  optional string street2 = 7;
-  optional string city = 8;
-  optional string state = 9;
-  optional string zip_code = 10;
-  optional string country = 11;
-  optional string website = 12;
+  string street1 = 6;
+  string street2 = 7;
+  string city = 8;
+  string state = 9;
+  string zip_code = 10;
+  string country = 11;
+  string website = 12;
 
-  optional PaymentType payment_type = 13;
+  PaymentType payment_type = 13;
   repeated Contact contacts = 14;
   repeated IdName tags = 15;
 
@@ -35,37 +35,37 @@ message Affiliate {
   repeated IdName traffic_vertical_categories = 18;
   repeated Country traffic_countries = 19;
 
-  optional double minimum_payment_threshold = 20;
-  optional double auto_payment_fee = 21;
-  optional string payment_to = 22;
-  optional string tax_class = 23;
-  optional string ssn_tax_id = 24;
-  optional bool pay_vat = 25;
-  optional string swift_iban = 26;
+  double minimum_payment_threshold = 20;
+  double auto_payment_fee = 21;
+  string payment_to = 22;
+  string tax_class = 23;
+  string ssn_tax_id = 24;
+  bool pay_vat = 25;
+  string swift_iban = 26;
 
-  optional bool referrals_enabled = 27;
-  optional IdName referred_by_affiliate = 28;
-  optional string referral_info = 29;
-  optional IdName billing_cycle = 30;
-  optional Currency currency = 31;
-  optional IdName currency_payment_setting = 32;
-  optional bool online_signup = 33;
-  optional bool pay_for_conversions = 34;
-  optional bool review = 35;
-  optional bool review_new_subaffiliates = 36;
-  optional bool suppression = 37;
+  bool referrals_enabled = 27;
+  IdName referred_by_affiliate = 28;
+  string referral_info = 29;
+  IdName billing_cycle = 30;
+  Currency currency = 31;
+  IdName currency_payment_setting = 32;
+  bool online_signup = 33;
+  bool pay_for_conversions = 34;
+  bool review = 35;
+  bool review_new_subaffiliates = 36;
+  bool suppression = 37;
   // suppression_cap omitted - cannot be reproduced in UI
-  optional PixelInfo pixel_info = 38;
-  optional bool fire_global_pixel = 39;
+  PixelInfo pixel_info = 38;
+  bool fire_global_pixel = 39;
   repeated Blacklist blacklists = 40;
-  optional string redirect_domain_override = 41;
-  optional bool auto_approve_campaigns = 42;
-  optional bool auto_approve_pixels = 43;
-  optional bool hide_offers = 44;
+  string redirect_domain_override = 41;
+  bool auto_approve_campaigns = 42;
+  bool auto_approve_pixels = 43;
+  bool hide_offers = 44;
 
   // signup_ip_address omitted - for privacy reasons
   // api_key omitted - for security reasons
-  optional TimeWithZone date_created = 45;
+  TimeWithZone date_created = 45;
   //date_last_accepted_terms omitted - cannot be reproduced in UI
-  optional string notes = 46;
+  string notes = 46;
 }

--- a/campaigns.proto
+++ b/campaigns.proto
@@ -1,4 +1,4 @@
-syntax = "proto2";
+syntax = "proto3";
 
 package cakeproto;
 
@@ -6,53 +6,53 @@ import "common.proto";
 
 message Campaign {
   message VoucherCode {
-    optional string name = 1;
-    optional IdName creative = 2;
-    optional TimeWithZone start_date = 3;
-    optional TimeWithZone expiration_date = 4;
-    optional bool active = 5;
+    string name = 1;
+    IdName creative = 2;
+    TimeWithZone start_date = 3;
+    TimeWithZone expiration_date = 4;
+    bool active = 5;
   }
 
-  optional int64 id = 1;
-  optional IdName type = 2;
-  optional IdName affiliate = 3;
-  optional IdName offer = 4;
-  optional IdName offer_contract = 5;
+  int64 id = 1;
+  IdName type = 2;
+  IdName affiliate = 3;
+  IdName offer = 4;
+  IdName offer_contract = 5;
 
-  optional bool original = 6;
+  bool original = 6;
   repeated IdName blocked_sub_affiliates = 7;
   repeated IdName blocked_creatives = 8;
-  optional IdName account_status = 9;
-  optional Currency currency = 10;
-  optional IdName media_type = 11;
-  optional IdName link_display_type = 12;
+  IdName account_status = 9;
+  Currency currency = 10;
+  IdName media_type = 11;
+  IdName link_display_type = 12;
   repeated EventOverride event_overrides = 13;
 
-  optional TimeWithZone date_contacted = 14;
-  optional TimeWithZone date_io_sent = 15;
-  optional TimeWithZone date_io_signed = 16;
-  optional TimeWithZone date_creative_sent = 17;
-  optional TimeWithZone date_pixel_placed = 18;
+  TimeWithZone date_contacted = 14;
+  TimeWithZone date_io_sent = 15;
+  TimeWithZone date_io_signed = 16;
+  TimeWithZone date_creative_sent = 17;
+  TimeWithZone date_pixel_placed = 18;
 
   repeated HistorizedMoney payouts = 19;
-  optional bool paid = 20;
-  optional bool paid_redirects = 21;
-  optional bool disable_prepop_appending = 22;
-  optional string redirect_domain = 23;
-  optional Cap click_cap = 24;
-  optional Cap conversion_cap = 25;
-  optional PixelInfo pixel_info = 26;
-  optional bool disable_upsells = 27;
-  optional bool paid_upsells = 28;
-  optional bool paid_upsells_same_session_only = 29;
-  optional bool clear_session_on_conversion = 30;
+  bool paid = 20;
+  bool paid_redirects = 21;
+  bool disable_prepop_appending = 22;
+  string redirect_domain = 23;
+  Cap click_cap = 24;
+  Cap conversion_cap = 25;
+  PixelInfo pixel_info = 26;
+  bool disable_upsells = 27;
+  bool paid_upsells = 28;
+  bool paid_upsells_same_session_only = 29;
+  bool clear_session_on_conversion = 30;
   repeated Upsell upsells = 31;
   repeated VoucherCode voucher_codes = 32;
-  optional string test_link = 33;
-  optional IdName redirect_offer = 34;
-  optional bool redirect404 = 35;
-  optional TimeWithZone date_created = 36;
-  optional TimeWithZone expiration_date = 37;
-  optional string notes = 38;
+  string test_link = 33;
+  IdName redirect_offer = 34;
+  bool redirect404 = 35;
+  TimeWithZone date_created = 36;
+  TimeWithZone expiration_date = 37;
+  string notes = 38;
 }
 

--- a/cap_states.proto
+++ b/cap_states.proto
@@ -1,29 +1,29 @@
-syntax = "proto2";
+syntax = "proto3";
 
 package cakeproto;
 
 import "common.proto";
 
 message CapState {
-  optional IdName advertiser = 1;
-  optional IdName offer = 2;
-  optional IdName offer_contract = 3;
+  IdName advertiser = 1;
+  IdName offer = 2;
+  IdName offer_contract = 3;
   // price_format omitted - get from offer entity
-  optional IdName affiliate = 4;
-  optional int64 campaign_id = 5;
+  IdName affiliate = 4;
+  int64 campaign_id = 5;
   // further campaign details omitted - get from campaign entity
 
-  optional string entity = 6;
-  optional IdName type = 7;
-  optional IdName interval = 8;
+  string entity = 6;
+  IdName type = 7;
+  IdName interval = 8;
 
-  optional bool active = 9;
-  optional TimeWithZone start_date = 10;
-  optional TimeWithZone end_date = 11;
-  optional int64 current = 12;
-  optional MaybeInt limit = 14;
+  bool active = 9;
+  TimeWithZone start_date = 10;
+  TimeWithZone end_date = 11;
+  int64 current = 12;
+  MaybeInt limit = 14;
   // percent_reached omitted - calculate it yourself
 
   // DEPRECATED
-  optional int64 limit_DEPRECATED = 13;
+  int64 limit_DEPRECATED = 13;
 }

--- a/circle.yml
+++ b/circle.yml
@@ -1,11 +1,14 @@
 machine:
   ruby:
-    version: 2.3.0
+    version: 2.3.2
   environment:
-    GOVERSION: 1.5.3
+    GOVERSION: 1.7.3
     GOROOT: ${HOME}/go
     PATH: ${GOROOT}/bin:${PATH}
+    PROTOCVERSION: 3.1.0
   post:
+    - curl -L -o protoc.zip https://github.com/google/protobuf/releases/download/v${PROTOCVERSION}/protoc-${PROTOCVERSION}-linux-x86_64.zip
+    - sudo unzip protoc.zip bin/protoc -d /usr/local && sudo chmod +x /usr/local/bin/protoc
     - curl https://storage.googleapis.com/golang/go${GOVERSION}.linux-amd64.tar.gz |tar xz
 dependencies:
   override:

--- a/clicks.proto
+++ b/clicks.proto
@@ -1,40 +1,40 @@
-syntax = "proto2";
+syntax = "proto3";
 
 package cakeproto;
 
 import "common.proto";
 
 message Click {
-  optional int64 id = 1;
-  optional int64 visitor_id = 2;
-  optional int64 request_session_id = 3;
-  optional TimeWithZone click_date = 4;
+  int64 id = 1;
+  int64 visitor_id = 2;
+  int64 request_session_id = 3;
+  TimeWithZone click_date = 4;
 
-  optional IdName affiliate = 5;
-  optional IdName advertiser = 6;
-  optional IdName offer = 7;
-  optional IdName offer_contract = 8;
-  optional int64 campaign_id = 9;
-  optional IdName creative = 10;
+  IdName affiliate = 5;
+  IdName advertiser = 6;
+  IdName offer = 7;
+  IdName offer_contract = 8;
+  int64 campaign_id = 9;
+  IdName creative = 10;
 
-  optional string sub_id1 = 11;
-  optional string sub_id2 = 12;
-  optional string sub_id3 = 13;
-  optional string sub_id4 = 14;
-  optional string sub_id5 = 15;
+  string sub_id1 = 11;
+  string sub_id2 = 12;
+  string sub_id3 = 13;
+  string sub_id4 = 14;
+  string sub_id5 = 15;
 
-  optional string ip_address = 16;
-  optional string user_agent = 17;
-  optional string referrer_url = 18;
+  string ip_address = 16;
+  string user_agent = 17;
+  string referrer_url = 18;
   // search_term omitted - no way to reproduce in UI
-  optional string request_url = 19;
-  optional string redirect_url = 20;
+  string request_url = 19;
+  string redirect_url = 20;
 
-  optional Country country = 21;
-  optional Region region = 22;
-  optional IdName isp = 23;
+  Country country = 21;
+  Region region = 22;
+  IdName isp = 23;
 
-  optional string disposition = 24;
-  optional int64 paid_action = 25;
+  string disposition = 24;
+  int64 paid_action = 25;
   // duplicate, duplicate_clicks and total_clicks omitted - no need for duplicate clicks
 }

--- a/common.proto
+++ b/common.proto
@@ -1,152 +1,152 @@
-syntax = "proto2";
+syntax = "proto3";
 
 package cakeproto;
 
 message IdName {
-  optional int64 id = 1;
-  optional string name = 2;
+  int64 id = 1;
+  string name = 2;
 }
 
 message TimeWithZone {
-  optional int64 unix_seconds = 1;
-  optional string timezone_location = 2;
+  int64 unix_seconds = 1;
+  string timezone_location = 2;
 }
 
 message Currency {
-  optional int64 id = 1;
-  optional string symbol = 2;
-  optional string name = 3;
-  optional string abbr = 4;
+  int64 id = 1;
+  string symbol = 2;
+  string name = 3;
+  string abbr = 4;
 }
 
 message PixelInfo {
-  optional string html = 1;
-  optional IdName hash_type = 2;
-  optional string postback_url = 3;
-  optional int64 postback_delay_ms = 4;
+  string html = 1;
+  IdName hash_type = 2;
+  string postback_url = 3;
+  int64 postback_delay_ms = 4;
 }
 
 message Money {
-  optional bool is_percentage = 1;
-  optional double amount = 2;
-  optional string formatted_amount = 3;
+  bool is_percentage = 1;
+  double amount = 2;
+  string formatted_amount = 3;
 }
 
 message MoneyWithCurrency {
-  optional int64 currency_id = 1;
-  optional double amount = 2;
-  optional string formatted_amount = 3;
+  int64 currency_id = 1;
+  double amount = 2;
+  string formatted_amount = 3;
 }
 
 message MediaType {
-  optional int64 id = 1;
-  optional string name = 2;
-  optional int64 category_id = 3;
-  optional string category_name = 4;
+  int64 id = 1;
+  string name = 2;
+  int64 category_id = 3;
+  string category_name = 4;
 }
 
 message Country {
-  optional string code = 1;
-  optional string name = 2;
+  string code = 1;
+  string name = 2;
 }
 
 message Region {
-  optional string code = 1;
-  optional string name = 2;
+  string code = 1;
+  string name = 2;
 }
 
 message SuppressionList {
-  optional int64 id = 1;
-  optional string name = 2;
-  optional IdName type = 3;
-  optional bool md5_only = 4;
-  optional TimeWithZone date_created = 5;
-  optional TimeWithZone date_updated = 6;
-  optional string list_location = 7;
+  int64 id = 1;
+  string name = 2;
+  IdName type = 3;
+  bool md5_only = 4;
+  TimeWithZone date_created = 5;
+  TimeWithZone date_updated = 6;
+  string list_location = 7;
 }
 
 message Contact {
-  optional int64 id = 1;
-  optional IdName type = 2;
-  optional IdName role = 3;
+  int64 id = 1;
+  IdName type = 2;
+  IdName role = 3;
   // department omitted - cannot be set in UI
 
-  optional string first_name = 4;
+  string first_name = 4;
   // middle_name omitted - cannot be set in UI
-  optional string last_name = 5;
-  optional string email_address = 6;
-  optional string title = 7;
-  optional string phone_work = 8;
-  optional string phone_cell = 9;
-  optional string phone_fax = 10;
-  optional string im_service = 11;
-  optional string im_name = 12;
+  string last_name = 5;
+  string email_address = 6;
+  string title = 7;
+  string phone_work = 8;
+  string phone_cell = 9;
+  string phone_fax = 10;
+  string im_service = 11;
+  string im_name = 12;
 
-  optional bool include_in_mass_emails = 13;
-  optional string notes = 14;
+  bool include_in_mass_emails = 13;
+  string notes = 14;
 }
 
 message Blacklist {
-  optional IdName advertiser = 1;
-  optional IdName offer = 2;
-  optional IdName affiliate = 3;
-  optional IdName sub_affiliate = 4;
-  optional IdName reason = 5;
-  optional IdName type = 6;
-  optional TimeWithZone date_created = 7;
+  IdName advertiser = 1;
+  IdName offer = 2;
+  IdName affiliate = 3;
+  IdName sub_affiliate = 4;
+  IdName reason = 5;
+  IdName type = 6;
+  TimeWithZone date_created = 7;
 }
 
 message Cap {
-  optional int64 limit = 1;
-  optional IdName interval = 2;
-  optional TimeWithZone start_date = 3;
-  optional bool review_no_redirect = 4;
+  int64 limit = 1;
+  IdName interval = 2;
+  TimeWithZone start_date = 3;
+  bool review_no_redirect = 4;
 }
 
 message HistorizedMoney {
-  optional bool current = 1;
-  optional TimeWithZone start_date = 2;
-  optional Money money = 3;
-  optional string notes = 4;
+  bool current = 1;
+  TimeWithZone start_date = 2;
+  Money money = 3;
+  string notes = 4;
 }
 
 message EventOverride {
-  optional int64 id = 1;
-  optional string name = 2;
-  optional bool active = 3;
-  optional string payout_fallback = 4;
-  optional string received_fallback = 5;
-  optional Cap cap = 6;
-  optional TimeWithZone start_date = 7;
-  optional bool review_no_redirect = 8;
+  int64 id = 1;
+  string name = 2;
+  bool active = 3;
+  string payout_fallback = 4;
+  string received_fallback = 5;
+  Cap cap = 6;
+  TimeWithZone start_date = 7;
+  bool review_no_redirect = 8;
 }
 
 message Upsell {
-  optional IdName offer_contract = 1;
-  optional IdName creative = 2;
-  optional int64 order = 3;
-  optional string top_html = 4;
-  optional string bottom_html = 5;
-  optional bool prepop_link = 6;
+  IdName offer_contract = 1;
+  IdName creative = 2;
+  int64 order = 3;
+  string top_html = 4;
+  string bottom_html = 5;
+  bool prepop_link = 6;
 }
 
 message ExchangeRate {
-  optional Currency base_currency = 1;
-  optional Currency quote_currency = 2;
-  optional TimeWithZone start_date = 3;
-  optional TimeWithZone end_date = 4;
-  optional double rate = 5;
+  Currency base_currency = 1;
+  Currency quote_currency = 2;
+  TimeWithZone start_date = 3;
+  TimeWithZone end_date = 4;
+  double rate = 5;
 }
 
 message Disposition {
-  optional int64 id = 1;
-  optional string name = 2;
-  optional IdName type = 3;
-  optional string contact = 4;
-  optional TimeWithZone disposition_date = 5;
+  int64 id = 1;
+  string name = 2;
+  IdName type = 3;
+  string contact = 4;
+  TimeWithZone disposition_date = 5;
 }
 
 message MaybeInt {
-  optional int64 value = 1;
-  optional bool has_value = 2;
+  int64 value = 1;
+  bool has_value = 2;
 }

--- a/conversion_changes.proto
+++ b/conversion_changes.proto
@@ -1,17 +1,17 @@
-syntax = "proto2";
+syntax = "proto3";
 
 package cakeproto;
 
 import "common.proto";
 
 message ConversionChange {
-  optional int64 id = 1;
-  optional TimeWithZone conversion_date = 2;
-  optional TimeWithZone last_updated = 3;
+  int64 id = 1;
+  TimeWithZone conversion_date = 2;
+  TimeWithZone last_updated = 3;
 
   // included are only fields which are actually changeable - load Conversion objects for full data
-  optional MoneyWithCurrency paid = 4;
-  optional MoneyWithCurrency received = 5;
-  optional Disposition current_disposition = 6;
-  optional string note = 7;
+  MoneyWithCurrency paid = 4;
+  MoneyWithCurrency received = 5;
+  Disposition current_disposition = 6;
+  string note = 7;
 }

--- a/conversions.proto
+++ b/conversions.proto
@@ -1,58 +1,58 @@
-syntax = "proto2";
+syntax = "proto3";
 
 package cakeproto;
 
 import "common.proto";
 
 message Conversion {
-  optional int64 id = 1;
-  optional int64 visitor_id = 2;
-  optional int64 request_session_id = 3;
-  optional int64 click_id = 4;
-  optional int64 click_request_session_id = 5;
-  optional TimeWithZone conversion_date = 6;
-  optional TimeWithZone click_date = 7;
-  optional TimeWithZone last_updated = 8;
+  int64 id = 1;
+  int64 visitor_id = 2;
+  int64 request_session_id = 3;
+  int64 click_id = 4;
+  int64 click_request_session_id = 5;
+  TimeWithZone conversion_date = 6;
+  TimeWithZone click_date = 7;
+  TimeWithZone last_updated = 8;
 
-  optional IdName event = 9;
-  optional IdName affiliate = 10;
-  optional IdName advertiser = 11;
-  optional IdName offer = 12;
-  optional IdName offer_contract = 13;
-  optional int64 campaign_id = 14;
-  optional IdName campaign_type = 15;
-  optional IdName creative = 16;
+  IdName event = 9;
+  IdName affiliate = 10;
+  IdName advertiser = 11;
+  IdName offer = 12;
+  IdName offer_contract = 13;
+  int64 campaign_id = 14;
+  IdName campaign_type = 15;
+  IdName creative = 16;
 
-  optional string sub_id1 = 17;
-  optional string sub_id2 = 18;
-  optional string sub_id3 = 19;
-  optional string sub_id4 = 20;
-  optional string sub_id5 = 21;
+  string sub_id1 = 17;
+  string sub_id2 = 18;
+  string sub_id3 = 19;
+  string sub_id4 = 20;
+  string sub_id5 = 21;
 
-  optional string ip_address = 22;
-  optional string click_ip_address = 36;
-  optional string user_agent = 23;
-  optional string click_user_agent = 37;
-  optional string source_type = 24;
+  string ip_address = 22;
+  string click_ip_address = 36;
+  string user_agent = 23;
+  string click_user_agent = 37;
+  string source_type = 24;
 
-  optional IdName price_format = 25;
+  IdName price_format = 25;
   // paid_unbilled and received_unbilled omitted - not available in ConversionChanges API
-  optional MoneyWithCurrency paid = 26;
-  optional MoneyWithCurrency received = 27;
+  MoneyWithCurrency paid = 26;
+  MoneyWithCurrency received = 27;
 
-  optional int64 step_reached = 28;
+  int64 step_reached = 28;
   // pixel_dropped, suppressed and returned omitted - not reproducible in UI
   // test omitted - fetch only non-test conversions
-  optional string transaction_id = 29;
-  optional Disposition current_disposition = 30;
-  optional MoneyWithCurrency order_total = 38;
+  string transaction_id = 29;
+  Disposition current_disposition = 30;
+  MoneyWithCurrency order_total = 38;
   // conversion_score omitted - not reproducible in UI
 
-  optional Country country = 31;
-  optional Region region = 32;
-  optional IdName language = 33;
-  optional IdName isp = 34;
+  Country country = 31;
+  Region region = 32;
+  IdName language = 33;
+  IdName isp = 34;
   // operating_system and browser omitted - parse user agent yourself
 
-  optional string note = 35;
+  string note = 35;
 }

--- a/creatives.proto
+++ b/creatives.proto
@@ -1,4 +1,4 @@
-syntax = "proto2";
+syntax = "proto3";
 
 package cakeproto;
 
@@ -6,25 +6,25 @@ import "common.proto";
 
 message Creative {
   message File {
-    optional int64 id = 1;
-    optional string name = 2;
-    optional string link = 3;
-    optional bool preview = 4;
-    optional TimeWithZone date_created = 5;
+    int64 id = 1;
+    string name = 2;
+    string link = 3;
+    bool preview = 4;
+    TimeWithZone date_created = 5;
   }
 
-  optional int64 id = 1;
-  optional string name = 2;
-  optional int64 offer_id = 3;
-  optional IdName type = 4;
-  optional IdName status = 5;
+  int64 id = 1;
+  string name = 2;
+  int64 offer_id = 3;
+  IdName type = 4;
+  IdName status = 5;
 
-  optional string offer_link_override = 6;
-  optional int64 width = 7;
-  optional int64 height = 8;
+  string offer_link_override = 6;
+  int64 width = 7;
+  int64 height = 8;
   repeated File files = 9;
 
-  optional TimeWithZone date_created = 10;
-  optional TimeWithZone expiration_date = 11;
-  optional string notes = 12;
+  TimeWithZone date_created = 10;
+  TimeWithZone expiration_date = 11;
+  string notes = 12;
 }

--- a/offers.proto
+++ b/offers.proto
@@ -1,4 +1,4 @@
-syntax = "proto2";
+syntax = "proto3";
 
 package cakeproto;
 
@@ -7,30 +7,30 @@ import "common.proto";
 message Offer {
   message Contract {
     message Rule {
-      optional int64 id = 1;
-      optional string name = 2;
-      optional int64 order = 3;
-      optional bool active = 4;
-      optional IdName redirect_offer = 5;
+      int64 id = 1;
+      string name = 2;
+      int64 order = 3;
+      bool active = 4;
+      IdName redirect_offer = 5;
     }
 
     message GeoTarget {
-      optional Country country = 1;
-      optional IdName redirect_contract = 2;
+      Country country = 1;
+      IdName redirect_contract = 2;
     }
 
-    optional int64 id = 1;
-    optional string name = 2;
+    int64 id = 1;
+    string name = 2;
 
-    optional IdName price_format = 3;
-    optional Money current_payout = 4;
-    optional Money current_received = 5;
+    IdName price_format = 3;
+    Money current_payout = 4;
+    Money current_received = 5;
 
-    optional string offer_link = 6;
-    optional string thankyou_link = 7;
+    string offer_link = 6;
+    string thankyou_link = 7;
 
-    optional bool hidden = 8;
-    optional IdName targeting_method = 9;
+    bool hidden = 8;
+    IdName targeting_method = 9;
 
     repeated EventOverride event_overrides = 10;
     repeated HistorizedMoney payouts = 11;
@@ -41,65 +41,65 @@ message Offer {
   }
 
   message Tier {
-    optional IdName price_format = 1;
-    optional IdName affiliate_tier = 2;
-    optional IdName contract = 3;
+    IdName price_format = 1;
+    IdName affiliate_tier = 2;
+    IdName contract = 3;
   }
 
-  optional int64 id = 1;
-  optional string name = 2;
+  int64 id = 1;
+  string name = 2;
 
-  optional IdName advertiser = 3;
-  optional IdName vertical = 4;
-  optional IdName type = 5;
-  optional IdName status = 6;
+  IdName advertiser = 3;
+  IdName vertical = 4;
+  IdName type = 5;
+  IdName status = 6;
 
-  optional bool hidden = 7;
-  optional string image_link = 8;
+  bool hidden = 7;
+  string image_link = 8;
 
-  optional int64 default_contract_id = 9;
+  int64 default_contract_id = 9;
   repeated Contract contracts = 10;
   repeated Tier tiers = 11;
   repeated IdName tags = 12;
   repeated MediaType allowed_media_types = 13;
-  optional Currency currency = 14;
-  optional bool ssl = 15;
+  Currency currency = 14;
+  bool ssl = 15;
 
   // suppression_amount omitted - no way to recreate in UI
-  optional Cap click_cap = 16;
-  optional Cap conversion_cap = 17;
+  Cap click_cap = 16;
+  Cap conversion_cap = 17;
 
-  optional int64 click_cookie_days = 18;
-  optional int64 impression_cookie_days = 19;
-  optional bool enable_view_thru_conversions = 20;
-  optional bool click_trumps_impression = 21;
-  optional bool disable_click_deduplication = 22;
-  optional bool disable_impression_deduplication = 23;
-  optional IdName voucher_code_attribution = 24;
-  optional bool last_touch = 25;
-  optional bool enable_transaction_id_deduplication = 26;
-  optional bool conversions_from_whitelist_only = 27;
-  optional PixelInfo pixel_info = 28;
-  optional bool fire_global_pixel = 29;
-  optional bool fire_pixel_on_non_paid_conversions = 30;
-  optional bool disable_prepop_appending = 31;
-  optional IdName redirect_offer = 32;
-  optional bool redirect404 = 33;
-  optional int64 session_regeneration_seconds = 34;
-  optional IdName session_regeneration_type = 35;
-  optional SuppressionList suppression_list = 36;
-  optional string unsubscribe_link = 37;
-  optional string preview_link = 38;
-  optional string description = 39;
-  optional string restrictions = 40;
-  optional string advertiser_extended_terms = 41;
-  optional string testing_instructions = 42;
-  optional string from_lines = 43;
-  optional string subject_lines = 44;
+  int64 click_cookie_days = 18;
+  int64 impression_cookie_days = 19;
+  bool enable_view_thru_conversions = 20;
+  bool click_trumps_impression = 21;
+  bool disable_click_deduplication = 22;
+  bool disable_impression_deduplication = 23;
+  IdName voucher_code_attribution = 24;
+  bool last_touch = 25;
+  bool enable_transaction_id_deduplication = 26;
+  bool conversions_from_whitelist_only = 27;
+  PixelInfo pixel_info = 28;
+  bool fire_global_pixel = 29;
+  bool fire_pixel_on_non_paid_conversions = 30;
+  bool disable_prepop_appending = 31;
+  IdName redirect_offer = 32;
+  bool redirect404 = 33;
+  int64 session_regeneration_seconds = 34;
+  IdName session_regeneration_type = 35;
+  SuppressionList suppression_list = 36;
+  string unsubscribe_link = 37;
+  string preview_link = 38;
+  string description = 39;
+  string restrictions = 40;
+  string advertiser_extended_terms = 41;
+  string testing_instructions = 42;
+  string from_lines = 43;
+  string subject_lines = 44;
   repeated Upsell upsells = 45;
-  optional string thankyou_html = 46;
-  optional string notes = 47;
+  string thankyou_html = 46;
+  string notes = 47;
 
-  optional TimeWithZone date_created = 48;
-  optional TimeWithZone expiration_date = 49;
+  TimeWithZone date_created = 48;
+  TimeWithZone expiration_date = 49;
 }


### PR DESCRIPTION
This upgrades all protobuf definitions to the latest version. The new format is wire-compatible, that means that all existing files can be read and written with both versions. 

This will change generated code for most languages. The changes should be minor, though. There is also no need to immediately update all applications, since the old format can parse/write the same data.