### PR TITLE
click_id, visitor_id and tracking_id as strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Used in
 
 ## Hacking
 
-- Read the whole [protobuf docs](https://developers.google.com/protocol-buffers/docs/proto)
+- Read the whole [protobuf docs](https://developers.google.com/protocol-buffers/docs/proto3)
   before even thinking about making a change!
 - Make your changes
 - Run `make deps` to install dependencies

--- a/clicks.proto
+++ b/clicks.proto
@@ -6,7 +6,7 @@ import "common.proto";
 
 message Click {
   int64 original_id = 1;
-  string id = 32;
+  string id = 35;
   int64 original_visitor_id = 2;
   string visitor_id = 33;
   int64 original_tracking_id = 30;

--- a/clicks.proto
+++ b/clicks.proto
@@ -5,11 +5,14 @@ package cakeproto;
 import "common.proto";
 
 message Click {
-  int64 id = 1;
-  int64 visitor_id = 2;
-  int64 tracking_id = 30;
-  int64 request_session_id = 3;
-  string request_session_guid = 31;
+  int64 original_id = 1;
+  string id = 32;
+  int64 original_visitor_id = 2;
+  string visitor_id = 33;
+  int64 original_tracking_id = 30;
+  string tracking_id = 34;
+  int64 original_request_session_id = 3;
+  string request_session_id = 31;
   TimeWithZone click_date = 4;
   int64 total_clicks = 29;
 

--- a/conversions.proto
+++ b/conversions.proto
@@ -6,13 +6,16 @@ import "common.proto";
 
 message Conversion {
   int64 id = 1;
-  int64 visitor_id = 2;
-  int64 tracking_id = 39;
-  int64 request_session_id = 3;
-  string request_session_guid = 40;
-  int64 click_id = 4;
-  int64 click_request_session_id = 5;
-  string click_request_session_guid = 41;
+  int64 original_visitor_id = 2;
+  string visitor_id = 42;
+  int64 original_tracking_id = 39;
+  string tracking_id = 43;
+  int64 original_request_session_id = 3;
+  string request_session_id = 40;
+  int64 original_click_id = 4;
+  string click_id = 44;
+  int64 original_click_request_session_id = 5;
+  string click_request_session_id = 41;
   TimeWithZone conversion_date = 6;
   TimeWithZone click_date = 7;
   TimeWithZone last_updated = 8;


### PR DESCRIPTION
From Cake NEWS from September 2017:

> We are also updating all APIs that include the Click ID, Request Session ID,
Tracking ID or Visitor ID in their response to treat them as strings vs. integers. 

https://trello.com/c/GAR47f6g

:exclamation: Before merging, check the field IDs for duplicates against master. :exclamation: 